### PR TITLE
Colorクラスにて範囲外アクセス発生

### DIFF
--- a/GameFramework/Color/Color.h
+++ b/GameFramework/Color/Color.h
@@ -114,26 +114,24 @@ namespace gameframework
 		/// </summary>
 		/// <param name="colorCode">代入するカラーコード</param>
 		/// <returns>thisの参照</returns>
+		/// <remarks>
+		/// <para>colorCodeの下位バイトからB→G→R→Aの順に1バイトずつ抜き出し、</para>
+		/// <para>それぞれ対応するメンバに保存する</para>
+		/// </remarks>
 		Color& operator=(DWORD colorCode)
 		{
-			const std::vector<COMPONENTS> colorComponents =
+			const std::vector<COMPONENTS> components =
 			{
-				COMPONENTS::ALPHA,
-				COMPONENTS::RED,
+				COMPONENTS::BLUE,
 				COMPONENTS::GREEN,
-				COMPONENTS::BLUE
+				COMPONENTS::RED,
+				COMPONENTS::ALPHA
 			};
 
-			int componentsMax = static_cast<int>(colorComponents.size());
-
-			for (int i = 0; componentsMax; ++i)
-			{
-				const int ONE_COLOR_BITS = 8;
-
-				int shiftNum = ONE_COLOR_BITS * (componentsMax - 1 - i);
-
-				DWORD componentColor = colorCode & (0xFF << shiftNum);
-				(*this)[colorComponents[i]] = static_cast<BYTE>((componentColor) >> shiftNum);
+			for (auto& component : components) {
+				int index = static_cast<int>(&component - &components[0]);
+				int shiftNum = CHAR_BIT * index;
+				(*this)[component] = (colorCode >> shiftNum) & 0xFF;
 			}
 
 			return *this;

--- a/GameFrameworkTest/ColorTest.cpp
+++ b/GameFrameworkTest/ColorTest.cpp
@@ -5,37 +5,79 @@
 using namespace gameframework;
 using COMPONENTS = Color::COMPONENTS;
 
-// GetColorCode()、operator[]は正常動作する前提
-
 // Color()
-TEST(ColorTest, DefaultCtor) {
+TEST(ColorTest, Ctor0) {
+	// Arrange
+	// Act
 	Color color;
 
-	ASSERT_EQ(0xFFFFFFFF, color.GetColorCode());
-	ASSERT_EQ(0xFF, color[COMPONENTS::ALPHA]);
-	ASSERT_EQ(0xFF, color[COMPONENTS::RED]);
-	ASSERT_EQ(0xFF, color[COMPONENTS::GREEN]);
-	ASSERT_EQ(0xFF, color[COMPONENTS::BLUE]);
+	// Assert
+	// GetColorCode()は正常動作する前提
+	DWORD ret = color.GetColorCode();
+	ASSERT_EQ(0xFFFFFFFF, ret);
 }
 
 // Color(DWORD colorCode)
 TEST(ColorTest, Ctor1) {
+	// Act
 	Color color(0x12345678);
 
+	// Assert
+	// GetColorCode()は正常動作する前提
+	DWORD ret = color.GetColorCode();
 	ASSERT_EQ(0x12345678, color.GetColorCode());
-	ASSERT_EQ(0x12, color[COMPONENTS::ALPHA]);
-	ASSERT_EQ(0x34, color[COMPONENTS::RED]);
-	ASSERT_EQ(0x56, color[COMPONENTS::GREEN]);
-	ASSERT_EQ(0x78, color[COMPONENTS::BLUE]);
 }
 
 // Color(BYTE alpha, BYTE red, BYTE green, BYTE blue)
 TEST(ColorTest, Ctor2) {
-	Color color(0x9A, 0xBC, 0xDE, 0xAA);
+	// Act
+	Color color(0x9A, 0xBC, 0xDE, 0xF0);
 
-	ASSERT_EQ(0x9ABCDEFF, color.GetColorCode());
-	ASSERT_EQ(0x9A, color[COMPONENTS::ALPHA]);
-	ASSERT_EQ(0xBC, color[COMPONENTS::RED]);
-	ASSERT_EQ(0xDE, color[COMPONENTS::GREEN]);
-	ASSERT_EQ(0xAA, color[COMPONENTS::BLUE]);
+	// Assert
+	// GetColorCode()は正常動作する前提
+	DWORD ret = color.GetColorCode();
+	ASSERT_EQ(0x9ABCDEF0, ret);
+}
+
+// DWORD GetColorCode() const
+TEST(ColorTest, GetColorCode) {
+	// Arrange
+	Color color(0x56789ABC);
+
+	// Act
+	DWORD ret = color.GetColorCode();
+
+	// Assert
+	ASSERT_EQ(0x56789ABC, ret);
+}
+
+// BYTE& operator[](COMPONENTS colorComponent)
+TEST(ColorTest, OperatorIndexer1) {
+	// Arrange
+	Color color(0x56789ABC);
+
+	// Act
+	BYTE a = color[COMPONENTS::ALPHA];
+	BYTE r = color[COMPONENTS::RED];
+	BYTE g = color[COMPONENTS::GREEN];
+	BYTE b = color[COMPONENTS::BLUE];
+
+	// Assert
+	ASSERT_EQ(0x56, a);
+	ASSERT_EQ(0x78, r);
+	ASSERT_EQ(0x9A, g);
+	ASSERT_EQ(0xBC, b);
+}
+
+// BYTE& operator[](COMPONENTS colorComponent)
+// 異常系
+TEST(ColorTest, OperatorIndexer2) {
+	// Arrange
+	Color color(0x56789ABC);
+
+	// Act
+	BYTE ret = color[static_cast<COMPONENTS>(4)];
+
+	// Assert
+	ASSERT_EQ(0x00, ret);
 }


### PR DESCRIPTION
- Color#operator= 内のループ処理をリファクタリング
- Colorクラスの単体テストを全体的に修正

Closes #52 