### PR TITLE
🐞 Color#operator+ がオーバーフローに対応していない

### DIFF
--- a/GameFramework/Color/Color.h
+++ b/GameFramework/Color/Color.h
@@ -144,7 +144,12 @@ namespace gameframework
 		/// <returns>足した結果のColor構造体</returns>
 		const Color operator+(const Color& rhs) const
 		{
-			return Color(m_alpha + rhs.m_alpha, m_red + rhs.m_red, m_green + rhs.m_green, m_blue + rhs.m_blue);
+			return Color(
+				Normalize(m_alpha + rhs.m_alpha),
+				Normalize(m_red   + rhs.m_red),
+				Normalize(m_green + rhs.m_green),
+				Normalize(m_blue  + rhs.m_blue)
+			);
 		}
 
 		const Color operator+(DWORD rhs) const
@@ -161,7 +166,12 @@ namespace gameframework
 		/// <returns>引いた結果のColor構造体</returns>
 		const Color operator-(const Color& rhs) const
 		{
-			return Color(m_alpha - rhs.m_alpha, m_red - rhs.m_red, m_green - rhs.m_green, m_blue - rhs.m_blue);
+			return Color(
+				Normalize(m_alpha - rhs.m_alpha),
+				Normalize(m_red   - rhs.m_red),
+				Normalize(m_green - rhs.m_green),
+				Normalize(m_blue  - rhs.m_blue)
+			);
 		}
 
 		const Color operator-(DWORD rhs) const
@@ -217,10 +227,11 @@ namespace gameframework
 		const Color operator*(float rhs) const
 		{
 			return Color(
-				static_cast<BYTE>(max(min(m_alpha * rhs, 255), 0)),
-				static_cast<BYTE>(max(min(m_red   * rhs, 255), 0)),
-				static_cast<BYTE>(max(min(m_green * rhs, 255), 0)),
-				static_cast<BYTE>(max(min(m_blue  * rhs, 255), 0)));
+				Normalize(m_alpha * rhs),
+				Normalize(m_red   * rhs),
+				Normalize(m_green * rhs),
+				Normalize(m_blue  * rhs)
+			);
 		}
 
 		/// <summary>
@@ -243,10 +254,11 @@ namespace gameframework
 		const Color operator/(int rhs) const
 		{
 			return Color(
-				static_cast<BYTE>(max(min(m_alpha / rhs, 255), 0)),
-				static_cast<BYTE>(max(min(m_red   / rhs, 255), 0)),
-				static_cast<BYTE>(max(min(m_green / rhs, 255), 0)),
-				static_cast<BYTE>(max(min(m_blue  / rhs, 255), 0)));
+				Normalize(m_alpha / rhs),
+				Normalize(m_red   / rhs),
+				Normalize(m_green / rhs),
+				Normalize(m_blue  / rhs)
+			);
 		}
 
 		/// <summary>
@@ -259,6 +271,21 @@ namespace gameframework
 			(*this) = (*this) / rhs;
 
 			return *this;
+		}
+
+	private:
+		/// <summary>
+		/// 各色の値を0x00～0xFFに正規化する
+		/// </summary>
+		/// <param name="componentValue">各色の値</param>
+		/// <returns>
+		/// <para>・cmponentValue ＜ 0x00の場合は0x00を返す</para>
+		/// <para>・0x00 ≦ componentValue ≦ 0xFFの場合はcomponentValueをそのまま返す</para>
+		/// <para>・0xFF ＜ componentValue 場合は0xFFを返す</para>
+		/// </returns>
+		inline BYTE Normalize(int componentValue) const
+		{
+			return static_cast<BYTE>(max(min(componentValue, 255), 0));
 		}
 	};
 }

--- a/GameFrameworkTest/ColorTest.cpp
+++ b/GameFrameworkTest/ColorTest.cpp
@@ -63,10 +63,10 @@ TEST(ColorTest, OperatorIndexer1) {
 	BYTE b = color[COMPONENTS::BLUE];
 
 	// Assert
-	ASSERT_EQ(0x56, a);
-	ASSERT_EQ(0x78, r);
-	ASSERT_EQ(0x9A, g);
-	ASSERT_EQ(0xBC, b);
+	EXPECT_EQ(0x56, a);
+	EXPECT_EQ(0x78, r);
+	EXPECT_EQ(0x9A, g);
+	EXPECT_EQ(0xBC, b);
 }
 
 // BYTE& operator[](COMPONENTS colorComponent)
@@ -80,4 +80,98 @@ TEST(ColorTest, OperatorIndexer2) {
 
 	// Assert
 	ASSERT_EQ(0x00, ret);
+}
+
+// const Color operator+(const Color& rhs) const
+TEST(ColorTest, OperatorPlus1) {
+	// Arrange
+	Color color1(0x12345678);
+	Color color2(0x12345678);
+
+	// Act
+	Color result = color1 + color2;
+
+	// Assert
+	BYTE a = result[COMPONENTS::ALPHA];
+	EXPECT_EQ(0x24, a);
+
+	BYTE r = result[COMPONENTS::RED];
+	EXPECT_EQ(0x68, r);
+
+	BYTE g = result[COMPONENTS::GREEN];
+	EXPECT_EQ(0xAC, g);
+
+	BYTE b = result[COMPONENTS::BLUE];
+	EXPECT_EQ(0xF0, b);
+}
+
+// const Color operator+(const Color& rhs) const
+TEST(ColorTest, OperatorPlus2) {
+	// Arrange
+	Color color1(0x89ABCDEF);
+	Color color2(0x9ABCDEF8);
+
+	// Act
+	Color result = color1 + color2;
+
+	// Assert
+	// 各色オーバーフローするので、最大値0xFFが設定されること
+	BYTE a = result[COMPONENTS::ALPHA];
+	EXPECT_EQ(0xFF, a);
+
+	BYTE r = result[COMPONENTS::RED];
+	EXPECT_EQ(0xFF, r);
+
+	BYTE g = result[COMPONENTS::GREEN];
+	EXPECT_EQ(0xFF, g);
+
+	BYTE b = result[COMPONENTS::BLUE];
+	EXPECT_EQ(0xFF, b);
+}
+
+// const Color operator-(const Color& rhs) const
+TEST(ColorTest, OperatorMinus1) {
+	// Arrange
+	Color color1(0x89ABCDEF);
+	Color color2(0x12345678);
+
+	// Act
+	Color result = color1 - color2;
+
+	// Assert
+	BYTE a = result[COMPONENTS::ALPHA];
+	EXPECT_EQ(0x77, a);
+
+	BYTE r = result[COMPONENTS::RED];
+	EXPECT_EQ(0x77, r);
+
+	BYTE g = result[COMPONENTS::GREEN];
+	EXPECT_EQ(0x77, g);
+
+	BYTE b = result[COMPONENTS::BLUE];
+	EXPECT_EQ(0x77, b);
+}
+
+// const Color operator-(const Color& rhs) const
+TEST(ColorTest, OperatorMinus2) {
+	// Arrange
+	Color color1(0x12345678);
+	Color color2(0xFFFFFFFF);
+
+	// Act
+	Color result = color1 - color2;
+
+	// Assert
+	// 各色アンダーフローするので、最小値0x00が設定されること
+	BYTE a = result[COMPONENTS::ALPHA];
+	EXPECT_EQ(0x00, a);
+
+	BYTE r = result[COMPONENTS::RED];
+	EXPECT_EQ(0x00, r);
+
+	BYTE g = result[COMPONENTS::GREEN];
+	EXPECT_EQ(0x00, g);
+
+	BYTE b = result[COMPONENTS::BLUE];
+	EXPECT_EQ(0x00, b);
 }


### PR DESCRIPTION
- 各色を0x00〜0xFFの間に正規化する関数を追加
- 四則演算子のオーバーロードの中で正規化関数を使用するよう修正

Closes #57 