### PR TITLE
頂点情報クラスの描画関数に引き渡すテクスチャの型を変更

### DIFF
--- a/GameFramework/GameFramework/Vertices/DirectX9Vertices.cpp
+++ b/GameFramework/GameFramework/Vertices/DirectX9Vertices.cpp
@@ -119,14 +119,14 @@ namespace gameframework
 		}
 	}
 
-	void DirectX9Vertices::Render(const Texture* pTexture)
+	void DirectX9Vertices::Render(const LPTEXTURE pTexture)
 	{
 		m_pDirectXGraphicDevice->SetFVF(
 			D3DFVF_XYZRHW |
 			D3DFVF_DIFFUSE |
 			D3DFVF_TEX1);
 
-		m_pDirectXGraphicDevice->SetTexture(0, pTexture->Get());
+		m_pDirectXGraphicDevice->SetTexture(0, pTexture);
 
 		m_pDirectXGraphicDevice->DrawPrimitiveUP(
 			D3DPT_TRIANGLEFAN,

--- a/GameFramework/GameFramework/Vertices/DirectX9Vertices.h
+++ b/GameFramework/GameFramework/Vertices/DirectX9Vertices.h
@@ -48,7 +48,7 @@ namespace gameframework
 		/// 描画を行う
 		/// </summary>
 		/// <param name="pTexture">描画する際に扱うテクスチャ</param>
-		void Render(const Texture* pTexture);
+		void Render(const LPTEXTURE pTexture);
 
 	private:
 		/// <summary>

--- a/GameFramework/GameFramework/Vertices/Vertices.h
+++ b/GameFramework/GameFramework/Vertices/Vertices.h
@@ -241,7 +241,7 @@ namespace gameframework
 		/// 描画を行う
 		/// </summary>
 		/// <param name="pTexture">描画する際に扱うテクスチャ</param>
-		virtual void Render(const Texture* pTexture) = 0;
+		virtual void Render(const LPTEXTURE pTexture) = 0;
 
 	protected:
 		/// <summary>


### PR DESCRIPTION
描画する際にテクスチャを引き渡せなかったので修正

Closes #84 