### PR TITLE
Verticesの中心以外を基点として矩形を生成する処理の修正

### DIFF
--- a/GameFramework/GameFramework/Vertices/Vertices.cpp
+++ b/GameFramework/GameFramework/Vertices/Vertices.cpp
@@ -58,10 +58,10 @@ namespace gameframework
 		m_baseSize = size;
 	}
 
-	void Vertices::SetPosBybottomRight(const D3DXVECTOR3& bottmRight, const RectSize& size)
+	void Vertices::SetPosBybottomRight(const D3DXVECTOR3& bottomRight, const RectSize& size)
 	{
-		m_center.x = bottmRight.x - 0.5f * size.m_width;
-		m_center.y = bottmRight.y - 0.5f * size.m_height;
+		m_center.x = bottomRight.x - 0.5f * size.m_width;
+		m_center.y = bottomRight.y - 0.5f * size.m_height;
 
 		m_baseSize = size;
 	}

--- a/GameFramework/GameFramework/Vertices/Vertices.cpp
+++ b/GameFramework/GameFramework/Vertices/Vertices.cpp
@@ -36,32 +36,32 @@ namespace gameframework
 
 	void Vertices::SetPosByTopLeft(const D3DXVECTOR3& topLeft, const RectSize& size)
 	{
-		m_center.x = topLeft.x * 0.5f + size.m_width;
-		m_center.y = topLeft.y * 0.5f + size.m_height;
+		m_center.x = topLeft.x + 0.5f * size.m_width;
+		m_center.y = topLeft.y + 0.5f * size.m_height;
 
 		m_baseSize = size;
 	}
 
-	void Vertices::SetPosBybottomLeft(const D3DXVECTOR3& topLeft, const RectSize& size)
+	void Vertices::SetPosBybottomLeft(const D3DXVECTOR3& bottomLeft, const RectSize& size)
 	{
-		m_center.x = topLeft.x * 0.5f + size.m_width;
-		m_center.y = topLeft.y * 0.5f - size.m_height;
+		m_center.x = bottomLeft.x + 0.5f * size.m_width;
+		m_center.y = bottomLeft.y - 0.5f * size.m_height;
 
 		m_baseSize = size;
 	}
 
-	void Vertices::SetPosByTopRight(const D3DXVECTOR3& topLeft, const RectSize& size)
+	void Vertices::SetPosByTopRight(const D3DXVECTOR3& topRight, const RectSize& size)
 	{
-		m_center.x = topLeft.x * 0.5f - size.m_width;
-		m_center.y = topLeft.y * 0.5f + size.m_height;
+		m_center.x = topRight.x - 0.5f * size.m_width;
+		m_center.y = topRight.y + 0.5f * size.m_height;
 
 		m_baseSize = size;
 	}
 
-	void Vertices::SetPosBybottomRight(const D3DXVECTOR3& topLeft, const RectSize& size)
+	void Vertices::SetPosBybottomRight(const D3DXVECTOR3& bottmRight, const RectSize& size)
 	{
-		m_center.x = topLeft.x * 0.5f - size.m_width;
-		m_center.y = topLeft.y * 0.5f - size.m_height;
+		m_center.x = bottmRight.x - 0.5f * size.m_width;
+		m_center.y = bottmRight.y - 0.5f * size.m_height;
 
 		m_baseSize = size;
 	}

--- a/GameFramework/GameFramework/Vertices/Vertices.h
+++ b/GameFramework/GameFramework/Vertices/Vertices.h
@@ -90,11 +90,11 @@ namespace gameframework
 
 		void SetPosByTopLeft(const D3DXVECTOR3& topLeft, const RectSize& size);
 
-		void SetPosBybottomLeft(const D3DXVECTOR3& topLeft, const RectSize& size);
+		void SetPosBybottomLeft(const D3DXVECTOR3& bottomLeft, const RectSize& size);
 
-		void SetPosByTopRight(const D3DXVECTOR3& topLeft, const RectSize& size);
+		void SetPosByTopRight(const D3DXVECTOR3& topRight, const RectSize& size);
 
-		void SetPosBybottomRight(const D3DXVECTOR3& topLeft, const RectSize& size);
+		void SetPosBybottomRight(const D3DXVECTOR3& bottomRight, const RectSize& size);
 
 		inline void SetSize(const RectSize& size)
 		{


### PR DESCRIPTION
## 元Issue
Closes #119
## 変更内容
- [x] 矩形の中心を求める処理の修正
- [x] 仮引数の名前の修正
## 補足
(#118)の修正を取り込んだ後でないとVerticesクラスが正常に動かないです